### PR TITLE
Feature/dao training create

### DIFF
--- a/src/main/kotlin/io/runnershigh/backend/shared/exception/BaseException.kt
+++ b/src/main/kotlin/io/runnershigh/backend/shared/exception/BaseException.kt
@@ -1,0 +1,9 @@
+package io.runnershigh.backend.shared.exception
+
+import org.springframework.http.HttpStatus
+
+abstract class BaseException(
+    val errorCode: String,
+    val httpStatus: HttpStatus,
+    override val message: String,
+) : RuntimeException(message)

--- a/src/main/kotlin/io/runnershigh/backend/shared/exception/ErrorResponse.kt
+++ b/src/main/kotlin/io/runnershigh/backend/shared/exception/ErrorResponse.kt
@@ -1,0 +1,27 @@
+package io.runnershigh.backend.shared.exception
+
+import org.springframework.http.HttpStatus
+import java.time.LocalDateTime
+
+data class ErrorResponse(
+    val timestamp: LocalDateTime = LocalDateTime.now(),
+    val status: Int,
+    val error: String,
+    val code: String,
+    val message: String,
+) {
+    companion object {
+        fun of(httpStatus: HttpStatus, errorCode: String, message: String): ErrorResponse {
+            return ErrorResponse(
+                status = httpStatus.value(),
+                error = httpStatus.reasonPhrase,
+                code = errorCode,
+                message = message,
+            )
+        }
+
+        fun of(e: BaseException): ErrorResponse {
+            return of(e.httpStatus, e.errorCode, e.message)
+        }
+    }
+}

--- a/src/main/kotlin/io/runnershigh/backend/shared/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/io/runnershigh/backend/shared/exception/GlobalExceptionHandler.kt
@@ -1,5 +1,6 @@
 package io.runnershigh.backend.shared.exception
 
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -12,5 +13,18 @@ class GlobalExceptionHandler {
         return ResponseEntity
             .status(e.httpStatus)
             .body(ErrorResponse.of(e))
+    }
+
+    @ExceptionHandler(Exception::class)
+    fun handleException(e: Exception): ResponseEntity<ErrorResponse> {
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(
+                ErrorResponse.of(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "SYSTEM-999",
+                    "서버 내부 오류가 발생했습니다."
+                )
+            )
     }
 }

--- a/src/main/kotlin/io/runnershigh/backend/shared/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/io/runnershigh/backend/shared/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,16 @@
+package io.runnershigh.backend.shared.exception
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+
+    @ExceptionHandler(BaseException::class)
+    fun handleBaseException(e: BaseException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity
+            .status(e.httpStatus)
+            .body(ErrorResponse.of(e))
+    }
+}

--- a/src/main/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCase.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCase.kt
@@ -1,6 +1,8 @@
 package io.runnershigh.backend.training.application.command
 
 import io.runnershigh.backend.training.domain.mapper.toEntity
+import io.runnershigh.backend.training.exception.TrainingException
+import io.runnershigh.backend.training.exception.TrainingExceptionType
 import io.runnershigh.backend.training.infrastructure.repository.command.TrainingSchedulesCommandRepository
 import io.runnershigh.backend.training.ui.dto.SaveTrainingSchedule
 import io.runnershigh.backend.user.util.LoginUserContext
@@ -18,7 +20,7 @@ class TrainingSchedulesCommandUseCase(
     fun createTrainingSchedule(dto: SaveTrainingSchedule) {
         // step01. 훈련일자 값 검증 -> 훈련일자가 현재보다 이전일 수 없음
         validateTrainingTime(dto.scheduleDate)
-        
+
         repository.save(dto.toEntity(loginUserContext.getCurrentUser()))
     }
 
@@ -26,7 +28,7 @@ class TrainingSchedulesCommandUseCase(
         val now = LocalDate.now()
 
         if (schedule.isBefore(now)) {
-            throw IllegalArgumentException("Invalid schedule") // TODO 예외 바꾸기
+            throw TrainingException(TrainingExceptionType.CANNOT_REGISTER_PAST_TRAINING)
         }
     }
 }

--- a/src/main/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCase.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCase.kt
@@ -1,0 +1,32 @@
+package io.runnershigh.backend.training.application.command
+
+import io.runnershigh.backend.training.domain.mapper.toEntity
+import io.runnershigh.backend.training.infrastructure.repository.command.TrainingSchedulesCommandRepository
+import io.runnershigh.backend.training.ui.dto.SaveTrainingSchedule
+import io.runnershigh.backend.user.util.LoginUserContext
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@Service
+@Transactional
+class TrainingSchedulesCommandUseCase(
+    private val repository: TrainingSchedulesCommandRepository,
+    private val loginUserContext: LoginUserContext,
+) {
+
+    fun createTrainingSchedule(dto: SaveTrainingSchedule) {
+        // step01. 훈련일자 값 검증 -> 훈련일자가 현재보다 이전일 수 없음
+        validateTrainingTime(dto.scheduleDate)
+        
+        repository.save(dto.toEntity(loginUserContext.getCurrentUser()))
+    }
+
+    private fun validateTrainingTime(schedule: LocalDate) {
+        val now = LocalDate.now()
+
+        if (schedule.isBefore(now)) {
+            throw IllegalArgumentException("Invalid schedule") // TODO 예외 바꾸기
+        }
+    }
+}

--- a/src/main/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCase.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCase.kt
@@ -3,12 +3,14 @@ package io.runnershigh.backend.training.application.command
 import io.runnershigh.backend.training.domain.mapper.toEntity
 import io.runnershigh.backend.training.exception.TrainingException
 import io.runnershigh.backend.training.exception.TrainingExceptionType
+import io.runnershigh.backend.training.infrastructure.entity.TrainingSchedules
 import io.runnershigh.backend.training.infrastructure.repository.command.TrainingSchedulesCommandRepository
 import io.runnershigh.backend.training.ui.dto.SaveTrainingSchedule
 import io.runnershigh.backend.user.util.LoginUserContext
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
+import java.time.ZoneId
 
 @Service
 @Transactional
@@ -16,19 +18,24 @@ class TrainingSchedulesCommandUseCase(
     private val repository: TrainingSchedulesCommandRepository,
     private val loginUserContext: LoginUserContext,
 ) {
+    private val MAX_FUTURE_DAYS = 365L
 
-    fun createTrainingSchedule(dto: SaveTrainingSchedule) {
+    fun createTrainingSchedule(dto: SaveTrainingSchedule): TrainingSchedules {
         // step01. 훈련일자 값 검증 -> 훈련일자가 현재보다 이전일 수 없음
         validateTrainingTime(dto.scheduledDate)
 
-        repository.save(dto.toEntity(loginUserContext.getCurrentUser()))
+        return repository.save(dto.toEntity(loginUserContext.getCurrentUser()))
     }
 
     private fun validateTrainingTime(schedule: LocalDate) {
-        val now = LocalDate.now()
+        val now = LocalDate.now(ZoneId.of("Asia/Seoul"))
 
         if (schedule.isBefore(now)) {
             throw TrainingException(TrainingExceptionType.CANNOT_REGISTER_PAST_TRAINING)
+        }
+
+        if (schedule.isAfter(now.plusDays(MAX_FUTURE_DAYS))) {
+            throw TrainingException(TrainingExceptionType.CANNOT_REGISTER_TRAINING_BEYOND_ONE_YEAR)
         }
     }
 }

--- a/src/main/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCase.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCase.kt
@@ -19,7 +19,7 @@ class TrainingSchedulesCommandUseCase(
 
     fun createTrainingSchedule(dto: SaveTrainingSchedule) {
         // step01. 훈련일자 값 검증 -> 훈련일자가 현재보다 이전일 수 없음
-        validateTrainingTime(dto.scheduleDate)
+        validateTrainingTime(dto.scheduledDate)
 
         repository.save(dto.toEntity(loginUserContext.getCurrentUser()))
     }

--- a/src/main/kotlin/io/runnershigh/backend/training/domain/mapper/TrainingMapper.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/domain/mapper/TrainingMapper.kt
@@ -1,0 +1,17 @@
+package io.runnershigh.backend.training.domain.mapper
+
+import io.runnershigh.backend.training.infrastructure.entity.TrainingSchedules
+import io.runnershigh.backend.training.ui.dto.SaveTrainingSchedule
+import io.runnershigh.backend.user.infrastructure.entity.UserEntity
+
+// 훈련 일정 mapper
+fun SaveTrainingSchedule.toEntity(user: UserEntity): TrainingSchedules {
+    return TrainingSchedules(
+        user = user,
+        title = this.title,
+        location = this.location,
+        scheduledDate = this.scheduleDate,
+        description = this.description,
+        status = this.status
+    )
+}

--- a/src/main/kotlin/io/runnershigh/backend/training/domain/mapper/TrainingMapper.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/domain/mapper/TrainingMapper.kt
@@ -4,13 +4,13 @@ import io.runnershigh.backend.training.infrastructure.entity.TrainingSchedules
 import io.runnershigh.backend.training.ui.dto.SaveTrainingSchedule
 import io.runnershigh.backend.user.infrastructure.entity.UserEntity
 
-// 훈련 일정 mapper
+// Training schedule mapper
 fun SaveTrainingSchedule.toEntity(user: UserEntity): TrainingSchedules {
     return TrainingSchedules(
         user = user,
         title = this.title,
         location = this.location,
-        scheduledDate = this.scheduleDate,
+        scheduledDate = this.scheduledDate,
         description = this.description,
         status = this.status
     )

--- a/src/main/kotlin/io/runnershigh/backend/training/exception/TrainingException.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/exception/TrainingException.kt
@@ -1,0 +1,11 @@
+package io.runnershigh.backend.training.exception
+
+import io.runnershigh.backend.shared.exception.BaseException
+
+class TrainingException(
+    val exceptionType: TrainingExceptionType,
+) : BaseException(
+    errorCode = exceptionType.errorCode,
+    httpStatus = exceptionType.httpStatus,
+    message = exceptionType.message,
+)

--- a/src/main/kotlin/io/runnershigh/backend/training/exception/TrainingExceptionType.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/exception/TrainingExceptionType.kt
@@ -1,0 +1,16 @@
+package io.runnershigh.backend.training.exception
+
+import org.springframework.http.HttpStatus
+
+enum class TrainingExceptionType(
+    val errorCode: String,
+    val httpStatus: HttpStatus,
+    val message: String,
+) {
+
+    CANNOT_REGISTER_PAST_TRAINING(
+        errorCode = "TRAINING_001",
+        httpStatus = HttpStatus.BAD_REQUEST,
+        message = "과거 시간에는 훈련을 등록할 수 없습니다."
+    )
+}

--- a/src/main/kotlin/io/runnershigh/backend/training/exception/TrainingExceptionType.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/exception/TrainingExceptionType.kt
@@ -12,5 +12,11 @@ enum class TrainingExceptionType(
         errorCode = "TRAINING_001",
         httpStatus = HttpStatus.BAD_REQUEST,
         message = "과거 시간에는 훈련을 등록할 수 없습니다."
+    ),
+
+    CANNOT_REGISTER_TRAINING_BEYOND_ONE_YEAR(
+        errorCode = "TRAINING_002",
+        httpStatus = HttpStatus.BAD_REQUEST,
+        message = "최대 1년까지만 훈련 일정을 등록할 수 있습니다."
     )
 }

--- a/src/main/kotlin/io/runnershigh/backend/training/infrastructure/entity/TrainingSchedules.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/infrastructure/entity/TrainingSchedules.kt
@@ -12,7 +12,7 @@ import java.time.LocalDate
 class TrainingSchedules(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long,
+    val id: Long = 0L,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/kotlin/io/runnershigh/backend/training/infrastructure/repository/command/TrainingSchedulesCommandRepository.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/infrastructure/repository/command/TrainingSchedulesCommandRepository.kt
@@ -1,0 +1,6 @@
+package io.runnershigh.backend.training.infrastructure.repository.command
+
+import io.runnershigh.backend.training.infrastructure.entity.TrainingSchedules
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface TrainingSchedulesCommandRepository : JpaRepository<TrainingSchedules, Long>

--- a/src/main/kotlin/io/runnershigh/backend/training/ui/dto/SaveTrainingSchedule.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/ui/dto/SaveTrainingSchedule.kt
@@ -6,7 +6,7 @@ import java.time.LocalDate
 data class SaveTrainingSchedule(
     val title: String,
     val location: String = "",
-    val scheduleDate: LocalDate,
+    val scheduledDate: LocalDate,
     val description: String = "",
     val status: TrainingStatus = TrainingStatus.PLANNED,
 )

--- a/src/main/kotlin/io/runnershigh/backend/training/ui/dto/SaveTrainingSchedule.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/ui/dto/SaveTrainingSchedule.kt
@@ -1,7 +1,7 @@
 package io.runnershigh.backend.training.ui.dto
 
 import io.runnershigh.backend.training.domain.enum.TrainingStatus
-import jakarta.validation.constraints.Future
+import jakarta.validation.constraints.FutureOrPresent
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import java.time.LocalDate
@@ -11,7 +11,7 @@ data class SaveTrainingSchedule(
     val title: String,
     val location: String = "",
     @field:NotNull(message = "훈련 예정일자는 필수입니다.")
-    @field:Future(message = "훈련 예정일자는 미래날짜여야합니다.")
+    @field:FutureOrPresent(message = "훈련 예정일자는 오늘 또는 미래날짜여야합니다.")
     val scheduledDate: LocalDate,
     val description: String = "",
     val status: TrainingStatus = TrainingStatus.PLANNED,

--- a/src/main/kotlin/io/runnershigh/backend/training/ui/dto/SaveTrainingSchedule.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/ui/dto/SaveTrainingSchedule.kt
@@ -1,0 +1,12 @@
+package io.runnershigh.backend.training.ui.dto
+
+import io.runnershigh.backend.training.domain.enum.TrainingStatus
+import java.time.LocalDate
+
+data class SaveTrainingSchedule(
+    val title: String,
+    val location: String = "",
+    val scheduleDate: LocalDate,
+    val description: String = "",
+    val status: TrainingStatus = TrainingStatus.PLANNED,
+)

--- a/src/main/kotlin/io/runnershigh/backend/training/ui/dto/SaveTrainingSchedule.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/ui/dto/SaveTrainingSchedule.kt
@@ -1,11 +1,17 @@
 package io.runnershigh.backend.training.ui.dto
 
 import io.runnershigh.backend.training.domain.enum.TrainingStatus
+import jakarta.validation.constraints.Future
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 import java.time.LocalDate
 
 data class SaveTrainingSchedule(
+    @field:NotBlank(message = "제목은 필수입니다.")
     val title: String,
     val location: String = "",
+    @field:NotNull(message = "훈련 예정일자는 필수입니다.")
+    @field:Future(message = "훈련 예정일자는 미래날짜여야합니다.")
     val scheduledDate: LocalDate,
     val description: String = "",
     val status: TrainingStatus = TrainingStatus.PLANNED,

--- a/src/test/kotlin/io/runnershigh/backend/fixture/UserFixture.kt
+++ b/src/test/kotlin/io/runnershigh/backend/fixture/UserFixture.kt
@@ -1,0 +1,30 @@
+package io.runnershigh.backend.fixture
+
+import io.runnershigh.backend.user.domain.enum.AgeGroup
+import io.runnershigh.backend.user.domain.enum.Gender
+import io.runnershigh.backend.user.domain.enum.UserStatus
+import io.runnershigh.backend.user.infrastructure.entity.UserEntity
+
+object UserFixture {
+    fun createDefault(
+        id: Int = 0,
+        loginId: String = "test1234",
+        password: String = "pw1234",
+        nickname: String = "테스트유저",
+        gender: Gender = Gender.MALE,
+        profileImage: String = "",
+        ageGroup: AgeGroup = AgeGroup.TWENTIES,
+        userStatus: UserStatus = UserStatus.ACTIVE,
+    ): UserEntity {
+        return UserEntity(
+            id = id,
+            loginId = loginId,
+            password = password,
+            nickname = nickname,
+            gender = gender,
+            profileImage = profileImage,
+            ageGroup = ageGroup,
+            userStatus = userStatus,
+        )
+    }
+}

--- a/src/test/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCaseTest.kt
+++ b/src/test/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCaseTest.kt
@@ -1,0 +1,98 @@
+package io.runnershigh.backend.training.application.command
+
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import io.runnershigh.backend.fixture.UserFixture
+import io.runnershigh.backend.training.domain.mapper.toEntity
+import io.runnershigh.backend.training.exception.TrainingException
+import io.runnershigh.backend.training.exception.TrainingExceptionType
+import io.runnershigh.backend.training.infrastructure.entity.TrainingSchedules
+import io.runnershigh.backend.training.infrastructure.repository.command.TrainingSchedulesCommandRepository
+import io.runnershigh.backend.training.ui.dto.SaveTrainingSchedule
+import io.runnershigh.backend.user.util.LoginUserContext
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.LocalDate
+import kotlin.test.assertEquals
+
+@ExtendWith(MockKExtension::class)
+class TrainingSchedulesCommandUseCaseTest {
+
+    @MockK
+    private lateinit var repository: TrainingSchedulesCommandRepository
+
+    @MockK
+    private lateinit var loginUserContext: LoginUserContext
+
+    private lateinit var useCase: TrainingSchedulesCommandUseCase
+
+    @BeforeEach
+    fun setup() {
+        useCase = TrainingSchedulesCommandUseCase(repository, loginUserContext)
+    }
+
+    @Test
+    @DisplayName("훈련일정 정상 저장")
+    fun createTrainingSchedule() {
+        //given
+        val dto = saveTrainingSchedule()
+        val user = userEntity()
+
+        every { loginUserContext.getCurrentUser() } returns user
+        every { repository.save(ofType<TrainingSchedules>()) } returns dto.toEntity(user)
+
+        //when
+        useCase.createTrainingSchedule(dto)
+
+        //then
+        verify(exactly = 1) {
+            loginUserContext.getCurrentUser()
+            repository.save(match { schedule ->
+                schedule.title == dto.title &&
+                        schedule.location == dto.location &&
+                        schedule.scheduledDate == dto.scheduleDate &&
+                        schedule.description == dto.description
+                schedule.user == user
+            })
+        }
+    }
+
+    @Test
+    @DisplayName("과거 날짜로 훈련일정 등록시 예외 발생")
+    fun createTrainingSchedule_withPastDate_throwsException() {
+        //given
+        val pastDate = LocalDate.now().minusDays(1)
+        val dto = saveTrainingSchedule().copy(scheduleDate = pastDate, title = "회복")
+        val user = userEntity()
+
+        every { loginUserContext.getCurrentUser() } returns user
+
+        //when
+        //then
+        val exception = assertThrows<TrainingException> {
+            useCase.createTrainingSchedule(dto)
+        }
+
+        assertEquals(TrainingExceptionType.CANNOT_REGISTER_PAST_TRAINING, exception.exceptionType)
+
+        verify(exactly = 0) {
+            repository.save(any())
+        }
+    }
+
+    private fun userEntity() = UserFixture.createDefault(id = 1)
+
+    private fun saveTrainingSchedule() = SaveTrainingSchedule(
+        title = "템포런",
+        location = "보라매공원",
+        scheduleDate = LocalDate.of(2025, 4, 5),
+        description = "빡세게 달려볼까"
+    )
+
+
+}

--- a/src/test/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCaseTest.kt
+++ b/src/test/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCaseTest.kt
@@ -105,6 +105,32 @@ class TrainingSchedulesCommandUseCaseTest {
         }
     }
 
+    @Test
+    @DisplayName("훈련일정 날짜가 1년이후로 등록시 오류발생")
+    fun createTrainingSchedule_withFutureDate_throwsException() {
+        //given
+        val futureDate = LocalDate.now().plusDays(366)
+        val dto = saveTrainingSchedule().copy(scheduledDate = futureDate, title = "마라톤")
+        val user = userEntity()
+
+        every { loginUserContext.getCurrentUser() } returns user
+
+        //when
+        //then
+        val exception = assertThrows<TrainingException> {
+            useCase.createTrainingSchedule(dto)
+        }
+
+        assertEquals(
+            TrainingExceptionType.CANNOT_REGISTER_TRAINING_BEYOND_ONE_YEAR,
+            exception.exceptionType
+        )
+
+        verify(exactly = 0) {
+            repository.save(any())
+        }
+    }
+
     private fun userEntity() = UserFixture.createDefault(id = 1)
 
     private fun saveTrainingSchedule() = SaveTrainingSchedule(

--- a/src/test/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCaseTest.kt
+++ b/src/test/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCaseTest.kt
@@ -85,12 +85,32 @@ class TrainingSchedulesCommandUseCaseTest {
         }
     }
 
+    @Test
+    @DisplayName("당일 훈련일정 등록 테스트")
+    fun createTrainingSchedule_withCurrentDate() {
+        //given
+        val currentDate = LocalDate.now()
+        val dto = saveTrainingSchedule().copy(scheduledDate = currentDate)
+        val user = userEntity()
+
+        every { loginUserContext.getCurrentUser() } returns user
+        every { repository.save(ofType<TrainingSchedules>()) } returns dto.toEntity(user)
+
+        //when
+        useCase.createTrainingSchedule(dto)
+
+        //then
+        verify(exactly = 1) {
+            repository.save(any())
+        }
+    }
+
     private fun userEntity() = UserFixture.createDefault(id = 1)
 
     private fun saveTrainingSchedule() = SaveTrainingSchedule(
         title = "템포런",
         location = "보라매공원",
-        scheduledDate = LocalDate.of(2025, 4, 5),
+        scheduledDate = LocalDate.now().plusDays(5),
         description = "빡세게 달려볼까"
     )
 

--- a/src/test/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCaseTest.kt
+++ b/src/test/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCaseTest.kt
@@ -55,7 +55,7 @@ class TrainingSchedulesCommandUseCaseTest {
             repository.save(match { schedule ->
                 schedule.title == dto.title &&
                         schedule.location == dto.location &&
-                        schedule.scheduledDate == dto.scheduleDate &&
+                        schedule.scheduledDate == dto.scheduledDate &&
                         schedule.description == dto.description
                 schedule.user == user
             })
@@ -67,7 +67,7 @@ class TrainingSchedulesCommandUseCaseTest {
     fun createTrainingSchedule_withPastDate_throwsException() {
         //given
         val pastDate = LocalDate.now().minusDays(1)
-        val dto = saveTrainingSchedule().copy(scheduleDate = pastDate, title = "회복")
+        val dto = saveTrainingSchedule().copy(scheduledDate = pastDate, title = "회복")
         val user = userEntity()
 
         every { loginUserContext.getCurrentUser() } returns user
@@ -90,7 +90,7 @@ class TrainingSchedulesCommandUseCaseTest {
     private fun saveTrainingSchedule() = SaveTrainingSchedule(
         title = "템포런",
         location = "보라매공원",
-        scheduleDate = LocalDate.of(2025, 4, 5),
+        scheduledDate = LocalDate.of(2025, 4, 5),
         description = "빡세게 달려볼까"
     )
 


### PR DESCRIPTION
### Service

1. 훈련일자 값 검증
2. DB 저장

### Repository

- repository > command 하위 패키지에 Spring JPA 생성

### 예외 처리 클래스

- 훈련 일정 날짜 오류
    - case1.훈련일정이 현재보다 이전인경우 : 과거시간에 훈련을 등록할 수 없습니다.

### 테스트

- 정상 저장
- 훈련일자 이전 날짜 입력시 에러 발생

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a structured error handling system with detailed error responses.
  - Added validation for training schedules to prevent registration of past dates and ensure future dates are within one year.
  - New functionality for creating training schedules with comprehensive data encapsulation.
  - Added a new `BaseException` class for better exception handling.
  - Introduced `TrainingException` and `TrainingExceptionType` for specific training-related errors.

- **Bug Fixes**
  - Updated the `id` property in the `TrainingSchedules` class to allow default initialization.

- **Tests**
  - Added unit tests for the `TrainingSchedulesCommandUseCase` to validate training schedule creation and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->