### PR TITLE
[BL-001] 상세 훈련 계획 저장 [DAO, Service]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     // spring
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.data:spring-data-commons")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 

--- a/src/main/kotlin/io/runnershigh/backend/training/application/command/TrainingPlanItemsUseCase.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/application/command/TrainingPlanItemsUseCase.kt
@@ -1,6 +1,8 @@
 package io.runnershigh.backend.training.application.command
 
 import io.runnershigh.backend.training.domain.mapper.toEntity
+import io.runnershigh.backend.training.exception.TrainingException
+import io.runnershigh.backend.training.exception.TrainingExceptionType
 import io.runnershigh.backend.training.infrastructure.entity.TrainingPlanItems
 import io.runnershigh.backend.training.infrastructure.entity.TrainingSchedules
 import io.runnershigh.backend.training.infrastructure.repository.command.TrainingPlanItemsRepository
@@ -23,9 +25,7 @@ class TrainingPlanItemsUseCase(
     }
 
     private fun getSchedule(scheduleId: Long): TrainingSchedules {
-        // TODO 에러 메세지 변경
         return trainingSchedulesRepository.findByIdOrNull(scheduleId)
-            ?: throw IllegalArgumentException("Schedule not found")
-
+            ?: throw TrainingException(TrainingExceptionType.CANNOT_FOUND_TRAINING_SCHEDULE)
     }
 }

--- a/src/main/kotlin/io/runnershigh/backend/training/application/command/TrainingPlanItemsUseCase.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/application/command/TrainingPlanItemsUseCase.kt
@@ -1,0 +1,28 @@
+package io.runnershigh.backend.training.application.command
+
+import io.runnershigh.backend.training.domain.mapper.toEntity
+import io.runnershigh.backend.training.infrastructure.entity.TrainingSchedules
+import io.runnershigh.backend.training.infrastructure.repository.command.TrainingPlanItemsRepository
+import io.runnershigh.backend.training.infrastructure.repository.command.TrainingSchedulesCommandRepository
+import io.runnershigh.backend.training.ui.dto.SaveTrainingPlanItem
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class TrainingPlanItemsUseCase(
+    private val trainingPlanItemsRepository: TrainingPlanItemsRepository,
+    private val trainingSchedulesRepository: TrainingSchedulesCommandRepository,
+) {
+
+    fun createTrainingItems(scheduleId: Long, dto: SaveTrainingPlanItem) {
+        val entity = dto.toEntity(getSchedule(scheduleId))
+        trainingPlanItemsRepository.save(entity)
+    }
+
+    private fun getSchedule(scheduleId: Long): TrainingSchedules {
+        // TODO 에러 메세지 변경
+        return trainingSchedulesRepository.findById(scheduleId)
+            .orElseThrow { IllegalArgumentException("Schedule with id $scheduleId not found") }
+    }
+}

--- a/src/main/kotlin/io/runnershigh/backend/training/application/command/TrainingPlanItemsUseCase.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/application/command/TrainingPlanItemsUseCase.kt
@@ -1,10 +1,12 @@
 package io.runnershigh.backend.training.application.command
 
 import io.runnershigh.backend.training.domain.mapper.toEntity
+import io.runnershigh.backend.training.infrastructure.entity.TrainingPlanItems
 import io.runnershigh.backend.training.infrastructure.entity.TrainingSchedules
 import io.runnershigh.backend.training.infrastructure.repository.command.TrainingPlanItemsRepository
 import io.runnershigh.backend.training.infrastructure.repository.command.TrainingSchedulesCommandRepository
 import io.runnershigh.backend.training.ui.dto.SaveTrainingPlanItem
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -15,14 +17,15 @@ class TrainingPlanItemsUseCase(
     private val trainingSchedulesRepository: TrainingSchedulesCommandRepository,
 ) {
 
-    fun createTrainingItems(scheduleId: Long, dto: SaveTrainingPlanItem) {
+    fun createTrainingItems(scheduleId: Long, dto: SaveTrainingPlanItem): TrainingPlanItems {
         val entity = dto.toEntity(getSchedule(scheduleId))
-        trainingPlanItemsRepository.save(entity)
+        return trainingPlanItemsRepository.save(entity)
     }
 
     private fun getSchedule(scheduleId: Long): TrainingSchedules {
         // TODO 에러 메세지 변경
-        return trainingSchedulesRepository.findById(scheduleId)
-            .orElseThrow { IllegalArgumentException("Schedule with id $scheduleId not found") }
+        return trainingSchedulesRepository.findByIdOrNull(scheduleId)
+            ?: throw IllegalArgumentException("Schedule not found")
+
     }
 }

--- a/src/main/kotlin/io/runnershigh/backend/training/domain/enum/DistanceUnit.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/domain/enum/DistanceUnit.kt
@@ -1,0 +1,18 @@
+package io.runnershigh.backend.training.domain.enum
+
+enum class DistanceUnit(val symbol: String, val conversionFactor: Double) {
+    METER("m", 1.0),
+    KILOMETER("km", 1000.0);
+
+    fun convertTo(value: Double, targetUnit: DistanceUnit): Double {
+        val valueInMeters = value * this.conversionFactor
+        return valueInMeters / targetUnit.conversionFactor
+    }
+
+    companion object {
+        fun fromString(symbol: String): DistanceUnit {
+            return entries.find { it.symbol.equals(symbol, ignoreCase = true) }
+                ?: throw IllegalArgumentException("지원하지 않는 거리 단위입니다: $symbol")
+        }
+    }
+}

--- a/src/main/kotlin/io/runnershigh/backend/training/domain/mapper/TrainingItemMapper.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/domain/mapper/TrainingItemMapper.kt
@@ -1,0 +1,21 @@
+package io.runnershigh.backend.training.domain.mapper
+
+import io.runnershigh.backend.training.infrastructure.entity.TrainingPlanItems
+import io.runnershigh.backend.training.infrastructure.entity.TrainingSchedules
+import io.runnershigh.backend.training.ui.dto.SaveTrainingPlanItem
+
+fun SaveTrainingPlanItem.toEntity(schedule: TrainingSchedules) = TrainingPlanItems(
+    schedule = schedule,
+    itemOrder = this.itemOrder,
+    targetType = this.targetType,
+    targetMinPace = this.targetMinPace,
+    targetMaxPace = this.targetMaxPace,
+    targetAvgPace = this.targetAvgPace,
+    runningTypeCode = this.runningTypeCode,
+    distanceUnit = this.distanceUnit,
+    targetDistance = this.targetDistance,
+    targetTime = this.targetTime,
+    estimatedDistance = this.estimatedDistance,
+    estimatedTime = this.estimatedTime,
+    note = this.note
+)

--- a/src/main/kotlin/io/runnershigh/backend/training/exception/TrainingExceptionType.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/exception/TrainingExceptionType.kt
@@ -18,5 +18,13 @@ enum class TrainingExceptionType(
         errorCode = "TRAINING_002",
         httpStatus = HttpStatus.BAD_REQUEST,
         message = "최대 1년까지만 훈련 일정을 등록할 수 있습니다."
+    ),
+
+    CANNOT_FOUND_TRAINING_SCHEDULE(
+        errorCode = "TRAINING_003",
+        httpStatus = HttpStatus.BAD_REQUEST,
+        message = "해당 정보로 등록된 훈련 일정을 찾을 수 없습니다."
     )
+
+
 }

--- a/src/main/kotlin/io/runnershigh/backend/training/infrastructure/entity/TrainingPlanItems.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/infrastructure/entity/TrainingPlanItems.kt
@@ -31,6 +31,14 @@ class TrainingPlanItems(
     @Comment("목표 페이스")
     var targetPace: LocalTime,
 
+    @Temporal(TemporalType.TIME)
+    @Comment("목표 페이스 시작 구간")
+    val targetStartPace: LocalTime,
+
+    @Temporal(TemporalType.TIME)
+    @Comment("목표 페이스 종료 구간")
+    val targetEndPace: LocalTime,
+
     @Comment("러닝타입코드")
     var runningTypeCode: Long,
 

--- a/src/main/kotlin/io/runnershigh/backend/training/infrastructure/entity/TrainingPlanItems.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/infrastructure/entity/TrainingPlanItems.kt
@@ -1,6 +1,7 @@
 package io.runnershigh.backend.training.infrastructure.entity
 
 import io.runnershigh.backend.shared.entity.BaseEntity
+import io.runnershigh.backend.training.domain.enum.DistanceUnit
 import io.runnershigh.backend.training.domain.enum.TargetType
 import jakarta.persistence.*
 import org.hibernate.annotations.Comment
@@ -11,15 +12,15 @@ import java.time.LocalTime
 class TrainingPlanItems(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long,
+    val id: Long = 0L,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "schedule_id")
     val schedule: TrainingSchedules,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "group_id")
-    val group: TrainingPlanGroups,
+    @JoinColumn(name = "group_id", nullable = true)
+    val group: TrainingPlanGroups? = null,
 
     @Comment("계획 순서")
     var itemOrder: Int,
@@ -28,33 +29,37 @@ class TrainingPlanItems(
     var targetType: TargetType,
 
     @Temporal(TemporalType.TIME)
-    @Comment("목표 페이스")
-    var targetPace: LocalTime,
+    @Comment("목표 최소 페이스")
+    val targetMinPace: LocalTime,
 
     @Temporal(TemporalType.TIME)
-    @Comment("목표 페이스 시작 구간")
-    val targetStartPace: LocalTime,
+    @Comment("목표 최대 페이스")
+    val targetMaxPace: LocalTime,
 
     @Temporal(TemporalType.TIME)
-    @Comment("목표 페이스 종료 구간")
-    val targetEndPace: LocalTime,
+    @Comment("목표 평균 페이스")
+    var targetAvgPace: LocalTime,
 
     @Comment("러닝타입코드")
-    var runningTypeCode: Long,
+    var runningTypeCode: Int,
+
+    @Comment("거리 단위")
+    @Enumerated(EnumType.STRING)
+    var distanceUnit: DistanceUnit?,
 
     @Comment("목표 거리")
-    var targetDistance: Double,
+    var targetDistance: Double?,
 
     @Comment("목표 시간")
-    var targetTime: LocalTime,
+    var targetTime: LocalTime?,
 
     @Comment("예상 거리")
-    var estimatedDistance: Double,
+    var estimatedDistance: Double?,
 
     @Comment("예상 시간")
-    var estimatedTime: LocalTime,
+    var estimatedTime: LocalTime?,
 
     @Comment("메모")
     @Lob
-    var note: String,
+    var note: String?,
 ) : BaseEntity()

--- a/src/main/kotlin/io/runnershigh/backend/training/infrastructure/repository/command/TrainingPlanItemsRepository.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/infrastructure/repository/command/TrainingPlanItemsRepository.kt
@@ -1,0 +1,6 @@
+package io.runnershigh.backend.training.infrastructure.repository.command
+
+import io.runnershigh.backend.training.infrastructure.entity.TrainingPlanItems
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface TrainingPlanItemsRepository : JpaRepository<TrainingPlanItems, Long>

--- a/src/main/kotlin/io/runnershigh/backend/training/ui/dto/SaveTrainingPlanItem.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/ui/dto/SaveTrainingPlanItem.kt
@@ -2,12 +2,14 @@ package io.runnershigh.backend.training.ui.dto
 
 import io.runnershigh.backend.training.domain.enum.DistanceUnit
 import io.runnershigh.backend.training.domain.enum.TargetType
+import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull
 import java.time.LocalTime
 
 data class SaveTrainingPlanItem(
 
     @field:NotNull
+    @field:Min(1)
     val itemOrder: Int,
 
     @field:NotNull

--- a/src/main/kotlin/io/runnershigh/backend/training/ui/dto/SaveTrainingPlanItem.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/ui/dto/SaveTrainingPlanItem.kt
@@ -1,0 +1,36 @@
+package io.runnershigh.backend.training.ui.dto
+
+import io.runnershigh.backend.training.domain.enum.DistanceUnit
+import io.runnershigh.backend.training.domain.enum.TargetType
+import jakarta.validation.constraints.NotNull
+import java.time.LocalTime
+
+data class SaveTrainingPlanItem(
+
+    @field:NotNull
+    val itemOrder: Int,
+
+    @field:NotNull
+    val targetType: TargetType,
+
+    @field:NotNull
+    val targetMinPace: LocalTime,
+
+    @field:NotNull
+    val targetMaxPace: LocalTime,
+
+    @field:NotNull
+    val targetAvgPace: LocalTime,
+
+    @field:NotNull
+    val runningTypeCode: Int,
+
+    val distanceUnit: DistanceUnit?,
+    val targetDistance: Double?,
+    val targetTime: LocalTime?,
+
+    var estimatedDistance: Double?,
+    var estimatedTime: LocalTime?,
+
+    val note: String?,
+)

--- a/src/test/kotlin/io/runnershigh/backend/fixture/TrainingScheduleFixture.kt
+++ b/src/test/kotlin/io/runnershigh/backend/fixture/TrainingScheduleFixture.kt
@@ -1,0 +1,28 @@
+package io.runnershigh.backend.fixture
+
+import io.runnershigh.backend.training.domain.enum.TrainingStatus
+import io.runnershigh.backend.training.infrastructure.entity.TrainingSchedules
+import io.runnershigh.backend.user.infrastructure.entity.UserEntity
+import java.time.LocalDate
+
+object TrainingScheduleFixture {
+    fun createDefault(
+        id: Long = 1L,
+        user: UserEntity = UserFixture.createDefault(),
+        title: String = "하프마라톤 대비",
+        location: String = "보라매 공원",
+        description: String = "보라매 공원 가볍게 러닝",
+        scheduledDate: LocalDate = LocalDate.now(),
+        status: TrainingStatus = TrainingStatus.PLANNED,
+    ): TrainingSchedules {
+        return TrainingSchedules(
+            id = id,
+            user = user,
+            title = title,
+            location = location,
+            description = description,
+            scheduledDate = scheduledDate,
+            status = status,
+        )
+    }
+}

--- a/src/test/kotlin/io/runnershigh/backend/training/application/command/TrainingPlanItemsUseCaseTest.kt
+++ b/src/test/kotlin/io/runnershigh/backend/training/application/command/TrainingPlanItemsUseCaseTest.kt
@@ -1,0 +1,76 @@
+package io.runnershigh.backend.training.application.command
+
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import io.runnershigh.backend.fixture.TrainingScheduleFixture
+import io.runnershigh.backend.training.domain.enum.DistanceUnit
+import io.runnershigh.backend.training.domain.enum.TargetType
+import io.runnershigh.backend.training.domain.mapper.toEntity
+import io.runnershigh.backend.training.infrastructure.entity.TrainingPlanItems
+import io.runnershigh.backend.training.infrastructure.repository.command.TrainingPlanItemsRepository
+import io.runnershigh.backend.training.infrastructure.repository.command.TrainingSchedulesCommandRepository
+import io.runnershigh.backend.training.ui.dto.SaveTrainingPlanItem
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.data.repository.findByIdOrNull
+import java.time.LocalTime
+
+@ExtendWith(MockKExtension::class)
+class TrainingPlanItemsUseCaseTest {
+
+    @MockK
+    private lateinit var planItemsRepository: TrainingPlanItemsRepository
+
+    @MockK
+    private lateinit var scheduleRepository: TrainingSchedulesCommandRepository
+
+    private lateinit var useCase: TrainingPlanItemsUseCase
+
+    @BeforeEach
+    fun setup() {
+        useCase = TrainingPlanItemsUseCase(planItemsRepository, scheduleRepository)
+    }
+
+    @Test
+    @DisplayName("훈련 상세계획 정상으로 저장")
+    fun createTrainingPlanItem() {
+        //given
+        val scheduleId = 1L
+        val scheduleEntity = TrainingScheduleFixture.createDefault(id = scheduleId)
+        val planItemDto = makeSaveTrainingPlanItemDto()
+
+        every { scheduleRepository.findByIdOrNull(scheduleId) } returns scheduleEntity
+        every { planItemsRepository.save(ofType<TrainingPlanItems>()) } returns planItemDto.toEntity(
+            scheduleEntity
+        )
+
+        //when
+        val result = useCase.createTrainingItems(scheduleId, planItemDto)
+
+        //then
+        assertEquals(planItemDto.toEntity(scheduleEntity).itemOrder, result.itemOrder)
+        verify { scheduleRepository.findByIdOrNull(scheduleId) }
+        verify { planItemsRepository.save(ofType<TrainingPlanItems>()) }
+    }
+
+    private fun makeSaveTrainingPlanItemDto() = SaveTrainingPlanItem(
+        itemOrder = 1,
+        targetType = TargetType.DISTANCE,  // Replace with an appropriate value
+        targetMinPace = LocalTime.of(0, 5, 0),  // Example time
+        targetMaxPace = LocalTime.of(0, 6, 0),  // Example time
+        targetAvgPace = LocalTime.of(0, 5, 30),  // Example time
+        runningTypeCode = 101,  // Example code
+        distanceUnit = DistanceUnit.KILOMETER,  // Replace with an appropriate value
+        targetDistance = 10.0,  // Example distance in km
+        targetTime = LocalTime.of(0, 50, 0),  // Example target time
+        estimatedDistance = 10.5,  // Example estimated distance
+        estimatedTime = LocalTime.of(0, 55, 0),  // Example estimated time
+        note = "Training notes example"
+    )
+
+}


### PR DESCRIPTION
# [BL-001] 상세 훈련 계획 저장 [DAO, Service]

## 📌 작업 설명

훈련 계획 생성 기능의 프론트엔드와 백엔드 구현

## 📋 작업 상세 내용

### 구현 범위

### Repository

- [x]  엔티티 필드 추가 (`TrainingPlanItems`)
    - 목표 페이스 시작 구간
    - 목표 페이스 종료 구간

### Service

- 훈련 상세 계획 저장
- 유효성 검사 로직 구현 (단순 입력값 검증x, 비즈니스 규칙에 따른 검증)

### 기술적 고려사항

- Kotlin의 데이터 클래스 활용하여 DTO 구현
    - 상세 훈련 계획 저장 DTO 필수 값 검증
        - 계획 순서, 훈련 목표
        - 목표 최소, 최대,평균 페이스 (화면에서 최소, 최대 입력받은 값으로 평균 페이스까지 산출)
        - 러닝타입코드

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced training plan management with an improved process for creating and handling plan items.
  - Introduced distance unit conversion support to enable seamless switching between metric values.
  - Added a new service for managing training plan items with error handling for missing schedules.
  
- **Refactor**
  - Optimized plan item data handling by refining pace measurements and incorporating optional fields for increased flexibility.

- **Tests**
  - Added comprehensive tests to validate the new training plan item functionality and data processing enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->