### PR TITLE
Feature/read training schedule

### DIFF
--- a/src/main/kotlin/io/runnershigh/backend/shared/util/DateUtils.kt
+++ b/src/main/kotlin/io/runnershigh/backend/shared/util/DateUtils.kt
@@ -1,0 +1,53 @@
+package io.runnershigh.backend.shared.util
+
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.temporal.TemporalAdjusters
+
+object DateUtils {
+
+
+    /**
+     * 주어진 날짜 또는 현재 날짜를 기준으로 가장 가까운 이전 일요일 날짜를 반환합니다.
+     *
+     * @param date 기준 날짜 (기본값: 현재 날짜)
+     * @return 가장 가까운 이전 일요일 날짜
+     */
+    fun findPreviousSunday(date: LocalDate = LocalDate.now()): LocalDate {
+        return if (date.dayOfWeek == DayOfWeek.SUNDAY) {
+            date
+        } else {
+            date.with(TemporalAdjusters.previous(DayOfWeek.SUNDAY))
+        }
+    }
+
+
+    /**
+     * 주어진 날짜 또는 현재 날짜를 기준으로 가장 가까운 이후 토요일 날짜를 반환합니다.
+     *
+     * @param date 기준 날짜 (기본값: 현재 날짜)
+     * @return 가장 가까운 이후 토요일 날짜
+     */
+    fun findNextSaturday(date: LocalDate = LocalDate.now()): LocalDate {
+        return if (date.dayOfWeek == DayOfWeek.SATURDAY) {
+            date
+        } else {
+            date.with(TemporalAdjusters.next(DayOfWeek.SATURDAY))
+        }
+    }
+
+
+    /**
+     * 주어진 날짜 또는 현재 날짜를 기준으로 해당 주의 경계를 반환합니다.
+     *
+     * 경계는 가장 가까운 이전 일요일과 이후 토요일로 정의됩니다.
+     *
+     * @param date 기준 날짜 (기본값: 현재 날짜)
+     * @return 해당 주의 경계를 나타내는 Pair (이전 일요일, 이후 토요일)
+     */
+    fun getWeekBoundaries(date: LocalDate = LocalDate.now()): Pair<LocalDate, LocalDate> {
+        val previousSunday = findPreviousSunday(date)
+        val nextSaturday = findNextSaturday(date)
+        return previousSunday to nextSaturday
+    }
+}

--- a/src/main/kotlin/io/runnershigh/backend/training/application/TrainingPlanGroupUseCase.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/application/TrainingPlanGroupUseCase.kt
@@ -7,7 +7,7 @@ import io.runnershigh.backend.training.infrastructure.entity.TrainingPlanGroups
 import io.runnershigh.backend.training.infrastructure.entity.TrainingSchedules
 import io.runnershigh.backend.training.infrastructure.repository.TrainingPlanGroupRepository
 import io.runnershigh.backend.training.infrastructure.repository.TrainingSchedulesRepository
-import io.runnershigh.backend.training.ui.dto.SaveTrainingPlanGroup
+import io.runnershigh.backend.training.ui.dto.request.SaveTrainingPlanGroup
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional

--- a/src/main/kotlin/io/runnershigh/backend/training/application/command/TrainingPlanItemsUseCase.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/application/command/TrainingPlanItemsUseCase.kt
@@ -7,7 +7,7 @@ import io.runnershigh.backend.training.infrastructure.entity.TrainingPlanItems
 import io.runnershigh.backend.training.infrastructure.entity.TrainingSchedules
 import io.runnershigh.backend.training.infrastructure.repository.TrainingPlanItemsRepository
 import io.runnershigh.backend.training.infrastructure.repository.TrainingSchedulesRepository
-import io.runnershigh.backend.training.ui.dto.SaveTrainingPlanItem
+import io.runnershigh.backend.training.ui.dto.request.SaveTrainingPlanItem
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional

--- a/src/main/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCase.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCase.kt
@@ -5,7 +5,7 @@ import io.runnershigh.backend.training.exception.TrainingException
 import io.runnershigh.backend.training.exception.TrainingExceptionType
 import io.runnershigh.backend.training.infrastructure.entity.TrainingSchedules
 import io.runnershigh.backend.training.infrastructure.repository.TrainingSchedulesRepository
-import io.runnershigh.backend.training.ui.dto.SaveTrainingSchedule
+import io.runnershigh.backend.training.ui.dto.request.SaveTrainingSchedule
 import io.runnershigh.backend.user.util.LoginUserContext
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional

--- a/src/main/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCase.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCase.kt
@@ -32,7 +32,7 @@ class TrainingSchedulesCommandUseCase(
         return trainingSchedulesRepository.save(dto.toEntity(loginUserContext.getCurrentUser()))
     }
 
-    fun getTrainingSchedules(date: LocalDate): List<ReadTrainingSchedule> {
+    fun getTrainingSchedules(): List<ReadTrainingSchedule> {
         // #1. 현재 로그인 유저 가져오기
         val loginUser = loginUserContext.getCurrentUser()
 
@@ -61,8 +61,13 @@ class TrainingSchedulesCommandUseCase(
     }
 
     fun getNextUpcomingTrainingSchedule(): ReadTrainingSchedule? {
+        // #1. 현재 로그인 유저 가져오기
         val loginUser = loginUserContext.getCurrentUser()
+
+        // #2. 다음 예정된 훈련 일정 가져오기
         val trainingSchedule = trainingScheduleQuerydsl.findNextUpcomingScheduleByUser(loginUser)
+
+        // #3. 엔티티 -> Schedule 변환
         return trainingSchedule?.toDto()
     }
 

--- a/src/main/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCase.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCase.kt
@@ -1,11 +1,15 @@
 package io.runnershigh.backend.training.application.command
 
+import io.runnershigh.backend.shared.util.DateUtils
+import io.runnershigh.backend.training.domain.mapper.toDto
 import io.runnershigh.backend.training.domain.mapper.toEntity
 import io.runnershigh.backend.training.exception.TrainingException
 import io.runnershigh.backend.training.exception.TrainingExceptionType
 import io.runnershigh.backend.training.infrastructure.entity.TrainingSchedules
 import io.runnershigh.backend.training.infrastructure.repository.TrainingSchedulesRepository
+import io.runnershigh.backend.training.infrastructure.repository.querydsl.TrainingScheduleQuerydsl
 import io.runnershigh.backend.training.ui.dto.request.SaveTrainingSchedule
+import io.runnershigh.backend.training.ui.dto.response.ReadTrainingSchedule
 import io.runnershigh.backend.user.util.LoginUserContext
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -15,7 +19,8 @@ import java.time.ZoneId
 @Service
 @Transactional
 class TrainingSchedulesCommandUseCase(
-    private val repository: TrainingSchedulesRepository,
+    private val trainingSchedulesRepository: TrainingSchedulesRepository,
+    private val trainingScheduleQuerydsl: TrainingScheduleQuerydsl,
     private val loginUserContext: LoginUserContext,
 ) {
     private val MAX_FUTURE_DAYS = 365L
@@ -24,7 +29,42 @@ class TrainingSchedulesCommandUseCase(
         // step01. 훈련일자 값 검증 -> 훈련일자가 현재보다 이전일 수 없음
         validateTrainingTime(dto.scheduledDate)
 
-        return repository.save(dto.toEntity(loginUserContext.getCurrentUser()))
+        return trainingSchedulesRepository.save(dto.toEntity(loginUserContext.getCurrentUser()))
+    }
+
+    fun getTrainingSchedules(date: LocalDate): List<ReadTrainingSchedule> {
+        // #1. 현재 로그인 유저 가져오기
+        val loginUser = loginUserContext.getCurrentUser()
+
+        // #2. 유저로 등록된 훈련 일정 목록 가져오기
+        val trainingSchedulesList = trainingScheduleQuerydsl.findByUser(loginUser)
+
+        // #3. 엔티티 -> Schedule 변환
+        return trainingSchedulesList.map(TrainingSchedules::toDto)
+//        return trainingSchedulesList.map { it.toDto() }
+    }
+
+    fun getCurrentWeekTrainingSchedules(): List<ReadTrainingSchedule> {
+        // #1. 현재 로그인 한 유저
+        val loginUser = loginUserContext.getCurrentUser()
+
+        // #2. 이번 주 훈련 일정 가져오기
+        val (previousSunday, nextSaturday) = DateUtils.getWeekBoundaries(LocalDate.now())
+        val trainingSchedulesList =
+            trainingScheduleQuerydsl.findCurrentWeekSchedulesByUser(
+                user = loginUser,
+                previousSunday = previousSunday,
+                nextSaturday = nextSaturday
+            )
+
+        // #3. 엔티티 -> Schedule 변환
+        return trainingSchedulesList.map(TrainingSchedules::toDto)
+    }
+
+    fun getNextUpcomingTrainingSchedule(): ReadTrainingSchedule? {
+        val loginUser = loginUserContext.getCurrentUser()
+        val trainingSchedule = trainingScheduleQuerydsl.findNextUpcomingScheduleByUser(loginUser)
+        return trainingSchedule?.toDto()
     }
 
     private fun validateTrainingTime(schedule: LocalDate) {

--- a/src/main/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCase.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCase.kt
@@ -41,7 +41,6 @@ class TrainingSchedulesCommandUseCase(
 
         // #3. 엔티티 -> Schedule 변환
         return trainingSchedulesList.map(TrainingSchedules::toDto)
-//        return trainingSchedulesList.map { it.toDto() }
     }
 
     fun getCurrentWeekTrainingSchedules(): List<ReadTrainingSchedule> {

--- a/src/main/kotlin/io/runnershigh/backend/training/domain/mapper/TrainingGroupMapper.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/domain/mapper/TrainingGroupMapper.kt
@@ -2,7 +2,7 @@ package io.runnershigh.backend.training.domain.mapper
 
 import io.runnershigh.backend.training.infrastructure.entity.TrainingPlanGroups
 import io.runnershigh.backend.training.infrastructure.entity.TrainingSchedules
-import io.runnershigh.backend.training.ui.dto.SaveTrainingPlanGroup
+import io.runnershigh.backend.training.ui.dto.request.SaveTrainingPlanGroup
 
 fun SaveTrainingPlanGroup.toEntity(schedule: TrainingSchedules) = TrainingPlanGroups(
     schedule = schedule,

--- a/src/main/kotlin/io/runnershigh/backend/training/domain/mapper/TrainingItemMapper.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/domain/mapper/TrainingItemMapper.kt
@@ -2,7 +2,7 @@ package io.runnershigh.backend.training.domain.mapper
 
 import io.runnershigh.backend.training.infrastructure.entity.TrainingPlanItems
 import io.runnershigh.backend.training.infrastructure.entity.TrainingSchedules
-import io.runnershigh.backend.training.ui.dto.SaveTrainingPlanItem
+import io.runnershigh.backend.training.ui.dto.request.SaveTrainingPlanItem
 
 fun SaveTrainingPlanItem.toEntity(schedule: TrainingSchedules) = TrainingPlanItems(
     schedule = schedule,

--- a/src/main/kotlin/io/runnershigh/backend/training/domain/mapper/TrainingScheduleMapper.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/domain/mapper/TrainingScheduleMapper.kt
@@ -1,7 +1,7 @@
 package io.runnershigh.backend.training.domain.mapper
 
 import io.runnershigh.backend.training.infrastructure.entity.TrainingSchedules
-import io.runnershigh.backend.training.ui.dto.SaveTrainingSchedule
+import io.runnershigh.backend.training.ui.dto.request.SaveTrainingSchedule
 import io.runnershigh.backend.user.infrastructure.entity.UserEntity
 
 // Training schedule mapper

--- a/src/main/kotlin/io/runnershigh/backend/training/domain/mapper/TrainingScheduleMapper.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/domain/mapper/TrainingScheduleMapper.kt
@@ -2,11 +2,22 @@ package io.runnershigh.backend.training.domain.mapper
 
 import io.runnershigh.backend.training.infrastructure.entity.TrainingSchedules
 import io.runnershigh.backend.training.ui.dto.request.SaveTrainingSchedule
+import io.runnershigh.backend.training.ui.dto.response.ReadTrainingSchedule
 import io.runnershigh.backend.user.infrastructure.entity.UserEntity
 
-// Training schedule mapper
+// request
 fun SaveTrainingSchedule.toEntity(user: UserEntity) = TrainingSchedules(
     user = user,
+    title = this.title,
+    location = this.location,
+    scheduledDate = this.scheduledDate,
+    description = this.description,
+    status = this.status
+)
+
+// response
+fun TrainingSchedules.toDto() = ReadTrainingSchedule(
+    id = this.id,
     title = this.title,
     location = this.location,
     scheduledDate = this.scheduledDate,

--- a/src/main/kotlin/io/runnershigh/backend/training/infrastructure/repository/querydsl/TrainingScheduleQuerydsl.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/infrastructure/repository/querydsl/TrainingScheduleQuerydsl.kt
@@ -6,6 +6,7 @@ import io.runnershigh.backend.training.infrastructure.entity.QTrainingSchedules.
 import io.runnershigh.backend.training.infrastructure.entity.TrainingSchedules
 import io.runnershigh.backend.user.infrastructure.entity.UserEntity
 import org.springframework.stereotype.Repository
+import java.time.LocalDate
 
 @Repository
 class TrainingScheduleQuerydsl(
@@ -15,9 +16,33 @@ class TrainingScheduleQuerydsl(
     fun findByUser(user: UserEntity): List<TrainingSchedules> {
         return queryFactory.selectFrom(trainingSchedules)
             .where(eqUser(user))
-            .orderBy(trainingSchedules.scheduledDate.asc())
+            .orderBy(trainingSchedules.scheduledDate.desc())
             .fetch()
     }
+
+    fun findCurrentWeekSchedulesByUser(
+        user: UserEntity,
+        previousSunday: LocalDate,
+        nextSaturday: LocalDate,
+    ): List<TrainingSchedules> {
+        return queryFactory.selectFrom(trainingSchedules)
+            .where(betweenSundayAndSaturday(previousSunday, nextSaturday))
+            .orderBy(trainingSchedules.scheduledDate.desc())
+            .fetch()
+    }
+
+    fun findNextUpcomingScheduleByUser(user: UserEntity): TrainingSchedules? {
+        return queryFactory.selectFrom(trainingSchedules)
+            .where(eqUser(user))
+            .orderBy(trainingSchedules.scheduledDate.asc())
+            .fetchFirst()
+    }
+
+    private fun betweenSundayAndSaturday(
+        beforeSunday: LocalDate,
+        afterSaturday: LocalDate,
+    ): BooleanExpression? =
+        trainingSchedules.scheduledDate.between(beforeSunday, afterSaturday)
 
     private fun eqUser(user: UserEntity): BooleanExpression? =
         trainingSchedules.user.eq(user)

--- a/src/main/kotlin/io/runnershigh/backend/training/infrastructure/repository/querydsl/TrainingScheduleQuerydsl.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/infrastructure/repository/querydsl/TrainingScheduleQuerydsl.kt
@@ -2,6 +2,7 @@ package io.runnershigh.backend.training.infrastructure.repository.querydsl
 
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
+import io.runnershigh.backend.training.domain.enum.TrainingStatus
 import io.runnershigh.backend.training.infrastructure.entity.QTrainingSchedules.trainingSchedules
 import io.runnershigh.backend.training.infrastructure.entity.TrainingSchedules
 import io.runnershigh.backend.user.infrastructure.entity.UserEntity
@@ -26,17 +27,24 @@ class TrainingScheduleQuerydsl(
         nextSaturday: LocalDate,
     ): List<TrainingSchedules> {
         return queryFactory.selectFrom(trainingSchedules)
-            .where(betweenSundayAndSaturday(previousSunday, nextSaturday))
+            .where(
+                eqUser(user),
+                betweenSundayAndSaturday(previousSunday, nextSaturday)
+            )
             .orderBy(trainingSchedules.scheduledDate.desc())
             .fetch()
     }
 
     fun findNextUpcomingScheduleByUser(user: UserEntity): TrainingSchedules? {
         return queryFactory.selectFrom(trainingSchedules)
-            .where(eqUser(user))
+            .where(
+                eqUser(user),
+                trainingSchedules.scheduledDate.goe(LocalDate.now()),
+            )
             .orderBy(trainingSchedules.scheduledDate.asc())
             .fetchFirst()
     }
+
 
     private fun betweenSundayAndSaturday(
         beforeSunday: LocalDate,

--- a/src/main/kotlin/io/runnershigh/backend/training/infrastructure/repository/querydsl/TrainingScheduleQuerydsl.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/infrastructure/repository/querydsl/TrainingScheduleQuerydsl.kt
@@ -1,0 +1,24 @@
+package io.runnershigh.backend.training.infrastructure.repository.querydsl
+
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import io.runnershigh.backend.training.infrastructure.entity.QTrainingSchedules.trainingSchedules
+import io.runnershigh.backend.training.infrastructure.entity.TrainingSchedules
+import io.runnershigh.backend.user.infrastructure.entity.UserEntity
+import org.springframework.stereotype.Repository
+
+@Repository
+class TrainingScheduleQuerydsl(
+    private val queryFactory: JPAQueryFactory,
+) {
+
+    fun findByUser(user: UserEntity): List<TrainingSchedules> {
+        return queryFactory.selectFrom(trainingSchedules)
+            .where(eqUser(user))
+            .orderBy(trainingSchedules.scheduledDate.asc())
+            .fetch()
+    }
+
+    private fun eqUser(user: UserEntity): BooleanExpression? =
+        trainingSchedules.user.eq(user)
+}

--- a/src/main/kotlin/io/runnershigh/backend/training/ui/dto/request/SaveTrainingPlanGroup.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/ui/dto/request/SaveTrainingPlanGroup.kt
@@ -1,4 +1,4 @@
-package io.runnershigh.backend.training.ui.dto
+package io.runnershigh.backend.training.ui.dto.request
 
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull

--- a/src/main/kotlin/io/runnershigh/backend/training/ui/dto/request/SaveTrainingPlanItem.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/ui/dto/request/SaveTrainingPlanItem.kt
@@ -1,4 +1,4 @@
-package io.runnershigh.backend.training.ui.dto
+package io.runnershigh.backend.training.ui.dto.request
 
 import io.runnershigh.backend.training.domain.enum.DistanceUnit
 import io.runnershigh.backend.training.domain.enum.TargetType

--- a/src/main/kotlin/io/runnershigh/backend/training/ui/dto/request/SaveTrainingPlanItem.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/ui/dto/request/SaveTrainingPlanItem.kt
@@ -31,8 +31,8 @@ data class SaveTrainingPlanItem(
     val targetDistance: Double?,
     val targetTime: LocalTime?,
 
-    var estimatedDistance: Double?,
-    var estimatedTime: LocalTime?,
+    val estimatedDistance: Double?,
+    val estimatedTime: LocalTime?,
 
     val note: String?,
 )

--- a/src/main/kotlin/io/runnershigh/backend/training/ui/dto/request/SaveTrainingSchedule.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/ui/dto/request/SaveTrainingSchedule.kt
@@ -1,4 +1,4 @@
-package io.runnershigh.backend.training.ui.dto
+package io.runnershigh.backend.training.ui.dto.request
 
 import io.runnershigh.backend.training.domain.enum.TrainingStatus
 import jakarta.validation.constraints.FutureOrPresent

--- a/src/main/kotlin/io/runnershigh/backend/training/ui/dto/response/ReadTrainingSchedule.kt
+++ b/src/main/kotlin/io/runnershigh/backend/training/ui/dto/response/ReadTrainingSchedule.kt
@@ -1,0 +1,13 @@
+package io.runnershigh.backend.training.ui.dto.response
+
+import io.runnershigh.backend.training.domain.enum.TrainingStatus
+import java.time.LocalDate
+
+data class ReadTrainingSchedule(
+    val id: Long,
+    val title: String,
+    val location: String,
+    val scheduledDate: LocalDate,
+    val description: String,
+    val status: TrainingStatus,
+)

--- a/src/test/kotlin/io/runnershigh/backend/fixture/TrainingScheduleFixture.kt
+++ b/src/test/kotlin/io/runnershigh/backend/fixture/TrainingScheduleFixture.kt
@@ -7,7 +7,7 @@ import java.time.LocalDate
 
 object TrainingScheduleFixture {
     fun createDefault(
-        id: Long = 1L,
+        id: Long = 0,
         user: UserEntity = UserFixture.createDefault(),
         title: String = "하프마라톤 대비",
         location: String = "보라매 공원",

--- a/src/test/kotlin/io/runnershigh/backend/fixture/TrainingScheduleFixture.kt
+++ b/src/test/kotlin/io/runnershigh/backend/fixture/TrainingScheduleFixture.kt
@@ -30,7 +30,7 @@ object TrainingScheduleFixture {
     }
 
     fun createReadTrainingSchedule(
-        id: Long = 1L,
+        id: Long = 0,
         title: String = "훈련1",
         location: String = "여의도 공원",
         scheduledDate: LocalDate = LocalDate.now(),

--- a/src/test/kotlin/io/runnershigh/backend/fixture/TrainingScheduleFixture.kt
+++ b/src/test/kotlin/io/runnershigh/backend/fixture/TrainingScheduleFixture.kt
@@ -1,7 +1,10 @@
 package io.runnershigh.backend.fixture
 
+import io.mockk.every
+import io.mockk.mockk
 import io.runnershigh.backend.training.domain.enum.TrainingStatus
 import io.runnershigh.backend.training.infrastructure.entity.TrainingSchedules
+import io.runnershigh.backend.training.ui.dto.response.ReadTrainingSchedule
 import io.runnershigh.backend.user.infrastructure.entity.UserEntity
 import java.time.LocalDate
 
@@ -24,5 +27,49 @@ object TrainingScheduleFixture {
             scheduledDate = scheduledDate,
             status = status,
         )
+    }
+
+    fun createReadTrainingSchedule(
+        id: Long = 1L,
+        title: String = "훈련1",
+        location: String = "여의도 공원",
+        scheduledDate: LocalDate = LocalDate.now(),
+        description: String = "고구마 캐기",
+        status: TrainingStatus = TrainingStatus.PLANNED,
+    ): ReadTrainingSchedule {
+        return ReadTrainingSchedule(
+            id = id,
+            title = title,
+            location = location,
+            scheduledDate = scheduledDate,
+            description = description,
+            status = status,
+        )
+    }
+
+    fun createEntityMock(
+        id: Long,
+        scheduledDate: LocalDate,
+        status: TrainingStatus = TrainingStatus.PLANNED,
+    ): TrainingSchedules {
+        val dto = createReadTrainingSchedule(id, scheduledDate = scheduledDate, status = status)
+
+        return mockk<TrainingSchedules>().apply {
+            every { this@apply.id } returns id
+            every { this@apply.scheduledDate } returns scheduledDate
+            every { this@apply.status } returns status
+            every { this@apply.title } returns dto.title
+            every { this@apply.location } returns dto.location
+            every { this@apply.description } returns dto.description
+        }
+    }
+
+    fun createMultipleEntityMocks(count: Int): List<TrainingSchedules> {
+        return (1..count).map { index ->
+            createEntityMock(
+                index.toLong(),
+                scheduledDate = LocalDate.now().plusDays(index.toLong() - 1)
+            )
+        }
     }
 }

--- a/src/test/kotlin/io/runnershigh/backend/shared/annotation/QuerydslTest.kt
+++ b/src/test/kotlin/io/runnershigh/backend/shared/annotation/QuerydslTest.kt
@@ -1,0 +1,11 @@
+package io.runnershigh.backend.shared.annotation
+
+import io.runnershigh.backend.shared.config.QuerydslTestConfig
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@DataJpaTest
+@Import(QuerydslTestConfig::class)
+annotation class QuerydslTest

--- a/src/test/kotlin/io/runnershigh/backend/shared/config/QuerydslTestConfig.kt
+++ b/src/test/kotlin/io/runnershigh/backend/shared/config/QuerydslTestConfig.kt
@@ -1,0 +1,14 @@
+package io.runnershigh.backend.shared.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+
+@TestConfiguration
+class QuerydslTestConfig {
+    @Bean
+    fun jpaQueryFactory(entityManager: EntityManager): JPAQueryFactory {
+        return JPAQueryFactory(entityManager)
+    }
+}

--- a/src/test/kotlin/io/runnershigh/backend/shared/util/DateUtilsTest.kt
+++ b/src/test/kotlin/io/runnershigh/backend/shared/util/DateUtilsTest.kt
@@ -1,0 +1,52 @@
+package io.runnershigh.backend.shared.util
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class DateUtilsTest {
+
+    @Test
+    @DisplayName("현재 날짜가 일요일인 경우 해당 날짜 반환")
+    fun findPreviousSunday_whenCurrendDateIsSunday_returnSameDay() {
+        //given
+        val sunday = LocalDate.of(2025, 4, 13)
+
+        //when
+        val result = DateUtils.findPreviousSunday(sunday)
+
+        //then
+        assertEquals(sunday, result)
+    }
+
+    @Test
+    @DisplayName("현재 날짜가 일요일이 아닌 경우 이전 일요일 반환")
+    fun findPreviousSunday_whenCurrentDateIsNotSunday_returnsPreviousSunday() {
+        //given
+        val wednesday = LocalDate.of(2025, 4, 9)
+        val expectedSunday = LocalDate.of(2025, 4, 6)
+
+        //when
+        val result = DateUtils.findPreviousSunday(wednesday)
+
+        //then
+        assertEquals(expectedSunday, result)
+    }
+
+    @Test
+    @DisplayName("현재 일자 기준으로 가장 가까운 이전 일요일, 가장 가까운 이후 토요일 반환")
+    fun findPreviousSundayAndNextSaturday_whenCurrentDate_returnsSundayAndSaturday() {
+        //given
+        val date = LocalDate.of(2025, 4, 13)
+        val expectedSunday = LocalDate.of(2025, 4, 13)
+        val expectedSaturday = LocalDate.of(2025, 4, 19)
+
+        //when
+        val result: Pair<LocalDate, LocalDate> = DateUtils.getWeekBoundaries(date)
+
+        //then
+        assertEquals(expectedSunday, result.first)
+        assertEquals(expectedSaturday, result.second)
+    }
+}

--- a/src/test/kotlin/io/runnershigh/backend/training/application/TrainingPlanGroupUseCaseTest.kt
+++ b/src/test/kotlin/io/runnershigh/backend/training/application/TrainingPlanGroupUseCaseTest.kt
@@ -12,7 +12,7 @@ import io.runnershigh.backend.training.exception.TrainingExceptionType
 import io.runnershigh.backend.training.infrastructure.entity.TrainingPlanGroups
 import io.runnershigh.backend.training.infrastructure.repository.TrainingPlanGroupRepository
 import io.runnershigh.backend.training.infrastructure.repository.TrainingSchedulesRepository
-import io.runnershigh.backend.training.ui.dto.SaveTrainingPlanGroup
+import io.runnershigh.backend.training.ui.dto.request.SaveTrainingPlanGroup
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach

--- a/src/test/kotlin/io/runnershigh/backend/training/application/command/TrainingPlanItemsUseCaseTest.kt
+++ b/src/test/kotlin/io/runnershigh/backend/training/application/command/TrainingPlanItemsUseCaseTest.kt
@@ -11,7 +11,7 @@ import io.runnershigh.backend.training.domain.mapper.toEntity
 import io.runnershigh.backend.training.infrastructure.entity.TrainingPlanItems
 import io.runnershigh.backend.training.infrastructure.repository.TrainingPlanItemsRepository
 import io.runnershigh.backend.training.infrastructure.repository.TrainingSchedulesRepository
-import io.runnershigh.backend.training.ui.dto.SaveTrainingPlanItem
+import io.runnershigh.backend.training.ui.dto.request.SaveTrainingPlanItem
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName

--- a/src/test/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCaseTest.kt
+++ b/src/test/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCaseTest.kt
@@ -10,7 +10,7 @@ import io.runnershigh.backend.training.exception.TrainingException
 import io.runnershigh.backend.training.exception.TrainingExceptionType
 import io.runnershigh.backend.training.infrastructure.entity.TrainingSchedules
 import io.runnershigh.backend.training.infrastructure.repository.TrainingSchedulesRepository
-import io.runnershigh.backend.training.ui.dto.SaveTrainingSchedule
+import io.runnershigh.backend.training.ui.dto.request.SaveTrainingSchedule
 import io.runnershigh.backend.user.util.LoginUserContext
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName

--- a/src/test/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCaseTest.kt
+++ b/src/test/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCaseTest.kt
@@ -1,16 +1,23 @@
 package io.runnershigh.backend.training.application.command
 
+import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.verify
+import io.runnershigh.backend.fixture.TrainingScheduleFixture
 import io.runnershigh.backend.fixture.UserFixture
+import io.runnershigh.backend.shared.util.DateUtils
+import io.runnershigh.backend.training.domain.enum.TrainingStatus
+import io.runnershigh.backend.training.domain.mapper.toDto
 import io.runnershigh.backend.training.domain.mapper.toEntity
 import io.runnershigh.backend.training.exception.TrainingException
 import io.runnershigh.backend.training.exception.TrainingExceptionType
 import io.runnershigh.backend.training.infrastructure.entity.TrainingSchedules
 import io.runnershigh.backend.training.infrastructure.repository.TrainingSchedulesRepository
+import io.runnershigh.backend.training.infrastructure.repository.querydsl.TrainingScheduleQuerydsl
 import io.runnershigh.backend.training.ui.dto.request.SaveTrainingSchedule
+import io.runnershigh.backend.training.ui.dto.response.ReadTrainingSchedule
 import io.runnershigh.backend.user.util.LoginUserContext
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -27,13 +34,17 @@ class TrainingSchedulesCommandUseCaseTest {
     private lateinit var repository: TrainingSchedulesRepository
 
     @MockK
+    private lateinit var trainingScheduleQuerydsl: TrainingScheduleQuerydsl
+
+    @MockK
     private lateinit var loginUserContext: LoginUserContext
 
     private lateinit var useCase: TrainingSchedulesCommandUseCase
 
     @BeforeEach
     fun setup() {
-        useCase = TrainingSchedulesCommandUseCase(repository, loginUserContext)
+        useCase =
+            TrainingSchedulesCommandUseCase(repository, trainingScheduleQuerydsl, loginUserContext)
     }
 
     @Test
@@ -130,6 +141,106 @@ class TrainingSchedulesCommandUseCaseTest {
             repository.save(any())
         }
     }
+
+    @Test
+    @DisplayName("유저가 등록한 훈련일정 전체 목록 가져오기")
+    fun getTrainingSchedules() {
+        //given
+        val mockUser = userEntity()
+        val mockTrainingSchedules = TrainingScheduleFixture.createMultipleEntityMocks(2)
+
+        every { loginUserContext.getCurrentUser() } returns mockUser
+        every { trainingScheduleQuerydsl.findByUser(mockUser) } returns mockTrainingSchedules
+
+        // when
+        val result = useCase.getTrainingSchedules(LocalDate.now())
+
+        // then
+        assertEquals(2, result.size)
+        assertEquals(TrainingStatus.PLANNED, result[0].status)
+        assertEquals("훈련1", result[1].title)
+
+        verify {
+            loginUserContext.getCurrentUser()
+            trainingScheduleQuerydsl.findByUser(mockUser)
+            mockTrainingSchedules[0].toDto()
+            mockTrainingSchedules[1].toDto()
+        }
+
+        confirmVerified(
+            loginUserContext,
+            trainingScheduleQuerydsl,
+            *mockTrainingSchedules.toTypedArray()
+        )
+    }
+
+    @Test
+    @DisplayName("유저가 등록한 이번 주(일-토) 훈련일정 목록 가져오기")
+    fun getCurrentlyPlannedTrainingSchedules() {
+        // Given
+        val currentDate = LocalDate.now()
+
+        // Mock - 'getCurrentUser' 반환
+        val mockUser = userEntity()
+        every { loginUserContext.getCurrentUser() } returns mockUser
+
+        // Mock - 'DateUtils.getWeekBoundaries' 함수 값 설정
+        val previousSunday = DateUtils.findPreviousSunday(currentDate) // 지난 일요일
+        val nextSaturday = DateUtils.findNextSaturday(currentDate) // 다음 토요일
+
+        // Mock - 일정 반환될 리스트 및 각 엔티티 설정
+        val mockSchedule1 = TrainingScheduleFixture.createEntityMock(
+            id = 1L,
+            scheduledDate = previousSunday.plusDays(1)
+        )
+        val mockSchedule2 = TrainingScheduleFixture.createEntityMock(
+            id = 2L,
+            scheduledDate = nextSaturday.minusDays(3)
+        )
+        val mockTrainingSchedules = listOf(mockSchedule1, mockSchedule2)
+
+        // Mock - 'findCurrentWeekSchedulesByUser' 반환값
+        every {
+            trainingScheduleQuerydsl.findCurrentWeekSchedulesByUser(
+                user = mockUser,
+                previousSunday = previousSunday,
+                nextSaturday = nextSaturday
+            )
+        } returns mockTrainingSchedules
+
+        // When
+        val result = useCase.getCurrentWeekTrainingSchedules()
+
+        // Then
+        // 반환된 사이즈와 값 검증
+        assertEquals(result.size, 2)
+        assertEquals(result[0].id, 1L)
+        assertEquals(result[1].id, 2L)
+
+        // Mock 호출 검증
+        verify {
+            loginUserContext.getCurrentUser()
+            trainingScheduleQuerydsl.findCurrentWeekSchedulesByUser(
+                user = mockUser,
+                previousSunday = previousSunday,
+                nextSaturday = nextSaturday
+            )
+            mockSchedule1.toDto()
+            mockSchedule2.toDto()
+        }
+    }
+
+    private fun makeReadTrainingScheduleDto(
+        id: Long, scheduledDate: LocalDate, status: TrainingStatus = TrainingStatus.PLANNED,
+        title: String = "title", location: String = "location", description: String = "description",
+    ) = ReadTrainingSchedule(
+        id = id,
+        scheduledDate = scheduledDate,
+        status = status,
+        title = title,
+        location = location,
+        description = description
+    )
 
     private fun userEntity() = UserFixture.createDefault(id = 1)
 

--- a/src/test/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCaseTest.kt
+++ b/src/test/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCaseTest.kt
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import java.time.LocalDate
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @ExtendWith(MockKExtension::class)
 class TrainingSchedulesCommandUseCaseTest {
@@ -153,12 +154,12 @@ class TrainingSchedulesCommandUseCaseTest {
         every { trainingScheduleQuerydsl.findByUser(mockUser) } returns mockTrainingSchedules
 
         // when
-        val result = useCase.getTrainingSchedules(LocalDate.now())
+        val result = useCase.getTrainingSchedules()
 
         // then
         assertEquals(2, result.size)
-        assertEquals(TrainingStatus.PLANNED, result[0].status)
-        assertEquals("훈련1", result[1].title)
+        assertTrue(result.any { it.status == TrainingStatus.PLANNED })
+        assertTrue(result.any { it.title == "훈련1" }) // 특정 순서에 종속되지 않고 포함만 되어있으면 검증 성공
 
         verify {
             loginUserContext.getCurrentUser()
@@ -229,18 +230,6 @@ class TrainingSchedulesCommandUseCaseTest {
             mockSchedule2.toDto()
         }
     }
-
-    private fun makeReadTrainingScheduleDto(
-        id: Long, scheduledDate: LocalDate, status: TrainingStatus = TrainingStatus.PLANNED,
-        title: String = "title", location: String = "location", description: String = "description",
-    ) = ReadTrainingSchedule(
-        id = id,
-        scheduledDate = scheduledDate,
-        status = status,
-        title = title,
-        location = location,
-        description = description
-    )
 
     private fun userEntity() = UserFixture.createDefault(id = 1)
 

--- a/src/test/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCaseTest.kt
+++ b/src/test/kotlin/io/runnershigh/backend/training/application/command/TrainingSchedulesCommandUseCaseTest.kt
@@ -215,8 +215,8 @@ class TrainingSchedulesCommandUseCaseTest {
         // Then
         // 반환된 사이즈와 값 검증
         assertEquals(result.size, 2)
-        assertEquals(result[0].id, 1L)
-        assertEquals(result[1].id, 2L)
+        assertTrue(result.any { it.id == 1L })
+        assertTrue(result.any { it.id == 2L })
 
         // Mock 호출 검증
         verify {

--- a/src/test/kotlin/io/runnershigh/backend/training/infrastructure/repository/querydsl/TrainingScheduleQuerydslTest.kt
+++ b/src/test/kotlin/io/runnershigh/backend/training/infrastructure/repository/querydsl/TrainingScheduleQuerydslTest.kt
@@ -1,0 +1,59 @@
+package io.runnershigh.backend.training.infrastructure.repository.querydsl
+
+import io.runnershigh.backend.fixture.TrainingScheduleFixture
+import io.runnershigh.backend.fixture.UserFixture
+import io.runnershigh.backend.shared.annotation.QuerydslTest
+import io.runnershigh.backend.user.infrastructure.entity.UserEntity
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Import
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@QuerydslTest
+@Import(TrainingScheduleQuerydsl::class)
+class TrainingScheduleQuerydslTest {
+
+    @Autowired
+    private lateinit var trainingScheduleQuerydsl: TrainingScheduleQuerydsl
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    @BeforeEach
+    fun setUp() {
+        val user = UserFixture.createDefault()
+        entityManager.persist(user)
+        val trainingSchedules = TrainingScheduleFixture.createDefault(
+            scheduledDate = LocalDate.now().plusDays(1),
+            user = user
+        )
+        entityManager.persist(trainingSchedules)
+        entityManager.flush()
+        entityManager.clear()
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("저장된 훈련 일정 정상 조회")
+    fun getTrainingSchedules() {
+        //given
+        val user = entityManager.createQuery(
+            "SELECT u FROM UserEntity u WHERE u.loginId = :loginId", UserEntity::class.java
+        )
+            .setParameter("loginId", "test1234")
+            .singleResult
+
+        //when
+        val schedules = trainingScheduleQuerydsl.findByUser(user)
+
+        //then
+        assertEquals(schedules.size, 1)
+        assertEquals(schedules.first().user, user)
+    }
+}


### PR DESCRIPTION
---

# [BL-005] 훈련 일정 조회

## 📌 작업 설명

- 훈련 일정 조회

## 📋 작업 상세 내용

- 다음 훈련 (현재 기준 제일 가까운 훈련 일정)
- 이번 주 훈련
- 전체 훈련

### UseCase

- 로그인 한 유저 정보로 등록된 훈련 일정 조회
- [x]  전체 훈련 조회
- [x]  다음 훈련 조회
- [x]  이번 주 훈련 조회

### Repository

- Querydsl 구현
- 공통 조회 조건: eq.회원
- [x]  전체 훈련 조회
    - 정렬: 훈련일자 desc
- [x]  이번 주 훈련
    - 조회 조건: 현재 일 기준 가까운 이전 일요일, 이후 토요일 
    → between 일요일 and 토요일
    - 정렬: 훈련일자 desc
- [x]  다음 훈련
    - 현재 일자 기준 보다 이후인 날짜 1건

### 기술적 고려사항

- Service단에서 반환 DTO → `ReadTrainingSchedule`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced training schedule management with new capabilities to fetch schedules by date, current week sessions, and next upcoming training.
	- Improved date handling ensures accurate weekly boundaries, providing precise and reliable schedule details.
	- Structured schedule responses now offer clear information such as session title, location, scheduled date, description, and status for a better user experience.
	- New utility functions for date manipulation, including methods to find the previous Sunday and next Saturday, as well as week boundaries.
	- Introduction of a new data class for structured training schedule responses.

- **Bug Fixes**
	- Updated import paths for various data transfer objects to reflect new package structures without affecting functionality.

- **Tests**
	- Added new test classes and methods to validate the functionality of training schedule queries and date utilities, enhancing test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->